### PR TITLE
Missing https://github.com/wildfly/wildfly-capabilities entry for capability org.wildfly.undertow.listener

### DIFF
--- a/org/wildfly/undertow/listener/capability.adoc
+++ b/org/wildfly/undertow/listener/capability.adoc
@@ -1,0 +1,30 @@
+NAME: org.wildfly.undertow.listener
+
+DESCRIPTION: Provides an Undertow listener
+
+REGISTERED BY:
+  
+  NAME: WildFly
+  URL:  https://github.com/wildfly/wildfly
+
+DYNAMIC: true
+
+PRIVATE: false
+
+SUPPORTS RUNTIME ONLY: false
+
+SERVICE PROVIDED:
+
+  CLASS: N/A
+  MODULE: N/A
+
+HARD REQUIREMENTS:
+
+  NAME: org.wildfly.io.worker
+  DYNAMIC: true
+
+  NAME: org.wildfly.io.buffer-pool
+  DYNAMIC: true
+
+  NAME: org.wildfly.network.socket-binding
+  DYNAMIC: true

--- a/registry.txt
+++ b/registry.txt
@@ -42,3 +42,4 @@ org.wildfly.remoting.endpoint
 org.wildfly.remoting.outbound-connection
 org.wildfly.request-controller
 org.wildfly.sar-deployment
+org.wildfly.undertow.listener


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/WFLY-7011
