### PR TITLE
WFLY-10490 Expose ModClusterServiceMBean as a mod_cluster capability

### DIFF
--- a/org/wildfly/mod_cluster/capability.adoc
+++ b/org/wildfly/mod_cluster/capability.adoc
@@ -1,6 +1,6 @@
 NAME: org.wildfly.mod_cluster
 
-DESCRIPTION: Main mod cluster capability
+DESCRIPTION: Provides mod_cluster service capability used to determine whether mod_cluster subsystem is available.
 
 REGISTERED BY:
   
@@ -20,8 +20,5 @@ SERVICE PROVIDED:
 
 HARD REQUIREMENTS:
 
-  NAME: org.wildfly.undertow.listener
-  DYNAMIC: true
-
-  NAME: org.wildfly.security.ssl-context
-  DYNAMIC: true
+  NAME: N/A
+  DYNAMIC: N/A

--- a/org/wildfly/mod_cluster/service/capability.adoc
+++ b/org/wildfly/mod_cluster/service/capability.adoc
@@ -1,0 +1,27 @@
+NAME: org.wildfly.mod_cluster.service
+
+DESCRIPTION: Provides mod_cluster service capability as a managed bean. The dynamic part of the capability corresponds to the proxy (configuration) name.
+
+REGISTERED BY:
+  
+  NAME: WildFly
+  URL:  https://github.com/wildfly/wildfly
+
+DYNAMIC: true
+
+PRIVATE: true
+
+SUPPORTS RUNTIME ONLY: true
+
+SERVICE PROVIDED:
+
+  CLASS: org.jboss.modcluster.ModClusterServiceMBean
+  MODULE: org.jboss.modcluster
+
+HARD REQUIREMENTS:
+
+  NAME: org.wildfly.undertow.listener
+  DYNAMIC: true
+
+  NAME: org.wildfly.security.ssl-context
+  DYNAMIC: true


### PR DESCRIPTION
Jira
https://issues.jboss.org/browse/WFLY-10490 Expose ModClusterServiceMBean as a mod_cluster capability

Related Jiras
https://issues.jboss.org/browse/WFLY-6803 Add multi-server support to mod_cluster
https://issues.jboss.org/browse/WFLY-10439 Modernize mod_cluster subsystem