### PR TITLE
[WFCORE-3396] Add Elytron certificate authority account capability

### DIFF
--- a/org/wildfly/security/certificate-authority-account/capability.adoc
+++ b/org/wildfly/security/certificate-authority-account/capability.adoc
@@ -1,0 +1,31 @@
+NAME: org.wildfly.security.certificate-authority-account
+
+DESCRIPTION: A certificate authority account
+
+REGISTERED BY:
+  
+  NAME: WildFly Core
+  URL:  https://github.com/wildfly/wildfly-core
+
+DYNAMIC: true
+
+PRIVATE: true
+
+SUPPORTS RUNTIME ONLY: false
+
+SERVICE PROVIDED:
+
+  CLASS: org.wildfly.security.x500.cert.acme.AcmeAccount
+  MODULE: org.wildfly.security.elytron
+
+CUSTOM RUNTIME API:
+
+  CLASS: N/A
+  MODULE: N/A
+
+HARD REQUIREMENTS:
+
+OPTIONAL REQUIREMENTS:
+
+RUNTIME ONLY REQUIREMENTS:
+

--- a/registry.txt
+++ b/registry.txt
@@ -54,6 +54,7 @@ org.wildfly.request-controller
 org.wildfly.sar-deployment
 org.wildfly.security.authentication-configuration
 org.wildfly.security.authentication-context
+org.wildfly.security.certificate-authority-account
 org.wildfly.security.credential-store
 org.wildfly.security.dir-context
 org.wildfly.security.http-authentication-factory


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-3396

Requires https://github.com/wildfly/wildfly-core/pull/3392 to be merged.