### PR TITLE
[WFCORE-4166] Add org.wildfly.remoting.http-listener-registry capability

### DIFF
--- a/org/wildfly/remoting/http-listener-registry/capability.adoc
+++ b/org/wildfly/remoting/http-listener-registry/capability.adoc
@@ -1,0 +1,19 @@
+NAME: org.wildfly.remoting.http-listener-registry
+
+DESCRIPTION: Provides a registry of all Undertow listeners, and the services that are registered on them.
+
+REGISTERED BY:
+  
+  NAME: WildFly Core
+  URL:  https://github.com/wildfly/wildfly-core
+
+DYNAMIC: false
+
+PRIVATE: false
+
+SUPPORTS RUNTIME ONLY: false
+
+SERVICE PROVIDED:
+
+  CLASS: io.undertow.server.ListenerRegistry
+  MODULE: io.undertow.core

--- a/registry.txt
+++ b/registry.txt
@@ -51,6 +51,7 @@ org.wildfly.network.outbound-socket-binding
 org.wildfly.network.socket-binding
 org.wildfly.remoting.connector
 org.wildfly.remoting.endpoint
+org.wildfly.remoting.http-listener-registry
 org.wildfly.remoting.outbound-connection
 org.wildfly.request-controller
 org.wildfly.sar-deployment


### PR DESCRIPTION
Add new capability added to wfcore 

wfcore issue: https://issues.jboss.org/browse/WFCORE-4166
PR: https://github.com/wildfly/wildfly-core/pull/3559
