### PR TITLE
[WFLY-13432] Provide capability for Undertow HTTP_UPGRADE_REGISTRY

### DIFF
--- a/org/wildfly/undertow/listener/http-upgrade-registry/capability.adoc
+++ b/org/wildfly/undertow/listener/http-upgrade-registry/capability.adoc
@@ -1,0 +1,24 @@
+NAME: org.wildfly.undertow.listener.http-upgrade-registry
+
+DESCRIPTION: Registry of handlers for HTTP Upgrade
+
+REGISTERED BY:
+  
+  NAME: WildFly
+  URL:  https://github.com/wildfly/wildfly
+
+DYNAMIC: true
+
+PRIVATE: false
+
+SUPPORTS RUNTIME ONLY: false
+
+SERVICE PROVIDED:
+
+  CLASS: io.undertow.server.handlers.ChannelUpgradeHandler
+  MODULE: org.wildfly.extension.undertow
+
+CUSTOM RUNTIME API:
+
+  CLASS: N/A
+  MODULE: N/A

--- a/registry.txt
+++ b/registry.txt
@@ -96,6 +96,7 @@ org.wildfly.undertow.host.location
 org.wildfly.undertow.http-invoker
 org.wildfly.undertow.http-invoker.host
 org.wildfly.undertow.listener
+org.wildfly.undertow.listener.http-upgrade-registry
 org.wildfly.undertow.mod_cluster_filter
 org.wildfly.undertow.reverse-proxy.host
 org.wildfly.undertow.server


### PR DESCRIPTION
This PR adds a capability for Undertow.
See the issue: https://issues.redhat.com/browse/WFLY-13432