### PR TITLE
[WFLY-13812] Record the remote naming capability and it's requirement…

### DIFF
--- a/org/wildfly/naming/remote/capability.adoc
+++ b/org/wildfly/naming/remote/capability.adoc
@@ -1,0 +1,29 @@
+NAME: org.wildfly.naming.remote
+
+DESCRIPTION: Remote connectivity to the naming server capability
+
+REGISTERED BY:
+
+  NAME: WildFly
+  URL:  https://github.com/wildfly/wildfly
+
+DYNAMIC: false
+
+PRIVATE: true
+
+SUPPORTS RUNTIME ONLY: false
+
+SERVICE PROVIDED:
+
+  CLASS: N/A
+  MODULE: N/A
+
+CUSTOM RUNTIME API:
+
+  CLASS: N/A
+  MODULE: N/A
+
+HARD REQUIREMENTS:
+
+  NAME: org.wildfly.remoting.endpoint
+  DYNAMIC: false


### PR DESCRIPTION
… for a remoting endpoint

Note the existence of the remote naming capability isn't part of WFLY-13812; it already existed.