### PR TITLE
WFLY-16794 Missing documentation for SmallRye Fault Tolerance capability

### DIFF
--- a/org/wildfly/microprofile/fault-tolerance/capability.adoc
+++ b/org/wildfly/microprofile/fault-tolerance/capability.adoc
@@ -1,0 +1,20 @@
+NAME: org.wildfly.microprofile.fault-tolerance
+
+DESCRIPTION: The presence of this capability in the capability registry indicates the presence of org.wildfly.microprofile.fault-tolerance-smallrye subsystem in the server.
+
+REGISTERED BY:
+
+  NAME: WildFly
+  URL:  https://github.com/wildfly/wildfly
+
+DYNAMIC: false
+
+PRIVATE: true
+
+SUPPORTS RUNTIME ONLY: false
+
+HARD REQUIREMENTS:
+
+  NAME: org.wildfly.microprofile.config
+  DYNAMIC: false
+

--- a/registry.txt
+++ b/registry.txt
@@ -47,6 +47,7 @@ org.wildfly.management.path-manager
 org.wildfly.messaging.activemq.broadcast-group
 org.wildfly.messaging.activemq.discovery-group
 org.wildfly.messaging.activemq.server
+org.wildfly.microprofile.fault-tolerance
 org.wildfly.naming
 org.wildfly.naming.remote
 org.wildfly.network.interface


### PR DESCRIPTION
Resolves
https://issues.redhat.com/browse/WFLY-16794